### PR TITLE
Update BlockDeviceZfs.filesystem_{info,type} to handle dataset device paths

### DIFF
--- a/iml_common/blockdevices/blockdevice_zfs.py
+++ b/iml_common/blockdevices/blockdevice_zfs.py
@@ -242,33 +242,39 @@ class BlockDeviceZfs(BlockDevice):
 
         :return: message describing zfs type and datasets found, None otherwise
         """
-        self._assert_zpool('filesystem_info')
+        try:
+            self._assert_zpool('filesystem_info')
+        except NotZpoolException:
+            blockdevice = BlockDevice(self._supported_device_types[0], self._device_path.split('/')[0])
 
-        with ZfsDevice(self._device_path, False):
-            try:
-                device_names = shell.Shell.try_run(['zfs', 'list', '-H', '-o', 'name', '-r', self._device_path]).split('\n')
+            return blockdevice.filesystem_info
+        else:
+            with ZfsDevice(self._device_path, False):
+                try:
+                    device_names = shell.Shell.try_run(['zfs', 'list', '-H', '-o', 'name', '-r', self._device_path]).split('\n')
 
-                datasets = [line.split('/', 1)[1] for line in device_names if '/' in line]
+                    datasets = [line.split('/', 1)[1] for line in device_names if '/' in line]
 
-                if datasets:
-                    return "Dataset%s '%s' found on zpool '%s'" % ('s' if (len(datasets) > 1) else '',
-                                                                   ','.join(datasets),
-                                                                   self._device_path)
-                return None
-            except OSError:                             # zfs not found
-                return "Unable to execute commands, check zfs is installed."
-            except shell.Shell.CommandExecutionError as e:    # no zpool 'self._device_path' found
-                return str(e)
+                    if datasets:
+                        return "Dataset%s '%s' found on zpool '%s'" % ('s' if (len(datasets) > 1) else '',
+                                                                       ','.join(datasets),
+                                                                       self._device_path)
+                    return None
+                except OSError:                             # zfs not found
+                    return "Unable to execute commands, check zfs is installed."
+                except shell.Shell.CommandExecutionError as e:    # no zpool 'self._device_path' found
+                    return str(e)
 
     @property
     def filesystem_type(self):
         """
-        Verify if any zfs datasets exist on zpool identified by self._device_path
+        Verify if any zfs datasets exist on zpool identified by self._device_path.
+
+        Given the interpretation that `formatting` implies creating datasets on a zpool, this method returns
+        `occupied` if zpool contains datasets and `unoccupied` otherwise.
 
         :return: 'zfs' if occupied or error encountered, None otherwise
         """
-        self._assert_zpool('filesystem_type')
-
         return self.preferred_fstype if self.filesystem_info is not None else None
 
     @property

--- a/iml_common/blockdevices/blockdevice_zfs.py
+++ b/iml_common/blockdevices/blockdevice_zfs.py
@@ -254,7 +254,7 @@ class BlockDeviceZfs(BlockDevice):
         else:
             with ZfsDevice(self._device_path, False):
                 try:
-                    device_names = shell.Shell.try_run(['zfs', 'list', '-H', '-o', 'name', '-r', self._device_path]).split('\n')
+                    device_names = Shell.try_run(['zfs', 'list', '-H', '-o', 'name', '-r', self._device_path]).split('\n')
                     datasets = [line.split('/', 1)[1] for line in device_names if '/' in line]
 
                     if datasets:
@@ -264,7 +264,7 @@ class BlockDeviceZfs(BlockDevice):
                     return None
                 except OSError:                             # zfs not found
                     return "Unable to execute commands, check zfs is installed."
-                except shell.Shell.CommandExecutionError as e:    # no zpool 'self._device_path' found
+                except Shell.CommandExecutionError as e:    # no zpool 'self._device_path' found
                     return str(e)
 
     @property

--- a/tests/blockdevices/test_blockdevice_zfs.py
+++ b/tests/blockdevices/test_blockdevice_zfs.py
@@ -86,7 +86,6 @@ kernel modules are functioning properly.
         self.assertRanAllCommandsInOrder()
 
     def test_filesystem_type_unoccupied(self):
-        # this should be called with device_path referencing a zpool
         self.add_command(('zfs', 'list', '-H', '-o', 'name', '-r', self.blockdevice._device_path),
                          stdout=self.blockdevice._device_path)
 
@@ -94,7 +93,6 @@ kernel modules are functioning properly.
         self.assertRanAllCommandsInOrder()
 
     def test_filesystem_type_occupied(self):
-        # this should be called with device_path referencing a zpool
         self.add_command(('zfs', 'list', '-H', '-o', 'name', '-r', self.blockdevice._device_path),
                          stdout='%(pool)s\n%(pool)s/dataset_1' % {'pool': self.blockdevice._device_path})
 
@@ -102,7 +100,6 @@ kernel modules are functioning properly.
         self.assertRanAllCommandsInOrder()
 
     def test_filesystem_info_unoccupied(self):
-        # this should be called with device_path referencing a zpool
         self.add_command(('zfs', 'list', '-H', '-o', 'name', '-r', self.blockdevice._device_path),
                          stdout=self.blockdevice._device_path)
 
@@ -110,7 +107,6 @@ kernel modules are functioning properly.
         self.assertRanAllCommandsInOrder()
 
     def test_filesystem_info_occupied(self):
-        # this should be called with device_path referencing a zpool
         self.add_command(('zfs', 'list', '-H', '-o', 'name', '-r', self.blockdevice._device_path),
                          stdout='%(pool)s\n%(pool)s/dataset_1' % {'pool': self.blockdevice._device_path})
 
@@ -119,13 +115,35 @@ kernel modules are functioning properly.
         self.assertRanAllCommandsInOrder()
 
     def test_filesystem_info_occupied_multiple(self):
-        # this should be called with device_path referencing a zpool
         self.add_command(('zfs', 'list', '-H', '-o', 'name', '-r', self.blockdevice._device_path),
                          stdout='%(pool)s\n%(pool)s/dataset_1\n%(pool)s/dataset_2' % {'pool':
                                                                                       self.blockdevice._device_path})
 
         self.assertEqual("Datasets 'dataset_1,dataset_2' found on zpool '%s'" %
                          self.blockdevice._device_path, self.blockdevice.filesystem_info)
+        self.assertRanAllCommandsInOrder()
+
+    def test_filesystem_info_dataset(self):
+        # should be possible with device_path referencing a dataset
+        dataset_blockdevice = BlockDeviceZfs('zfs', self.dataset_path)
+
+        self.add_command(('zfs', 'list', '-H', '-o', 'name', '-r', self.blockdevice._device_path),
+                         stdout='%(pool)s\n%(pool)s/dataset_1\n%(pool)s/dataset_2' % {'pool':
+                                                                                      self.blockdevice._device_path})
+
+        self.assertEqual("Datasets 'dataset_1,dataset_2' found on zpool '%s'" %
+                         self.blockdevice._device_path, dataset_blockdevice.filesystem_info)
+        self.assertRanAllCommandsInOrder()
+
+    def test_filesystem_type_dataset(self):
+        # should be possible with device_path referencing a dataset
+        dataset_blockdevice = BlockDeviceZfs('zfs', self.dataset_path)
+
+        self.add_command(('zfs', 'list', '-H', '-o', 'name', '-r', self.blockdevice._device_path),
+                         stdout='%(pool)s\n%(pool)s/dataset_1\n%(pool)s/dataset_2' % {'pool':
+                                                                                      self.blockdevice._device_path})
+
+        self.assertEqual('zfs', dataset_blockdevice.filesystem_type)
         self.assertRanAllCommandsInOrder()
 
     def test_uuid(self):


### PR DESCRIPTION
filesystem_type returns None if zpool has no datasets, 'zfs' otherwise and does this by calling filesystem_info which returns a list of the datasets or None if no datasets.

change both methods to accept  dataset paths, needed for https://github.com/intel-hpdd/intel-manager-for-lustre/pull/174