### PR TITLE
Restart instead of start

### DIFF
--- a/iml_common/lib/service_control.py
+++ b/iml_common/lib/service_control.py
@@ -211,7 +211,7 @@ class ServiceControlEL7(ServiceControl):
         return shell.Shell.run_canned_error_message(['systemctl', 'disable', self.service_name])
 
     def _start(self):
-        return shell.Shell.run_canned_error_message(['systemctl', 'start', self.service_name])
+        return shell.Shell.run_canned_error_message(['systemctl', 'restart', self.service_name])
 
     def _stop(self):
         return shell.Shell.run_canned_error_message(['systemctl', 'stop', self.service_name])


### PR DESCRIPTION
On upgrade, services need to be restarted.  "restart" gives same assurance
that process will bestarted as "start", but on upgrade services will be
restarted instead of this being a no-op.

Signed-off-by: Nathaniel Clark <nclark@whamcloud.com>